### PR TITLE
Fix link to download CSV by making it preserve global domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ which you will find at [cjdelisle/pkt-explorer-backend](https://github.com/cjdel
 Once the backend API server has been setup, you can compile this block explorer using
 the following:
 
-    REACT_APP_BACKEND_URL=https://path.to.your.server/ npm run build
+    REACT_APP_BACKEND_URL=https://path.to.your.server npm run build
 
 Afterword a production version of the app will be placed in the `build` folder.
 If you do not set the `REACT_APP_BACKEND_URL` environment variable, your explorer
@@ -24,7 +24,7 @@ This is a reactjs app so you can read about deployment on react's
 ## Development
 For development, you will want to run the app in development mode using:
 
-    REACT_APP_BACKEND_URL=https://path.to.your.server/ npm run start
+    REACT_APP_BACKEND_URL=https://path.to.your.server npm run start
 
 Once the server is running, you can open [http://localhost:3000](http://localhost:3000)
 to view it in the browser.

--- a/src/components/CsvDl/CsvDl.js
+++ b/src/components/CsvDl/CsvDl.js
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 // import PropTypes from 'prop-types'
 import { MdFileDownload } from 'react-icons/md'
 import DateRangePicker from '@wojtekmaj/react-daterange-picker'
+import endpoints from '../../utils/endpoints'
 
 const Row = styled.div`
   /* margin-top: 1rem; */
@@ -88,7 +89,7 @@ const CsvDl = ({ addr, dateRange, setDateRange }) => {
     }
   }
 
-  const csvUrl = useMemo(() => `https://pkt.cash/api/v1/PKT/pkt/address/${addr}/income/${dateRange[0].toISOString().replace(/T.*$/, '')}/${dateRange[1].toISOString().replace(/T.*$/, '')}?mining=${miningFlag}&csv=1`, [dateRange, miningFlag, addr])
+  const csvUrl = useMemo(() => `${endpoints.base}/address/${addr}/income/${dateRange[0].toISOString().replace(/T.*$/, '')}/${dateRange[1].toISOString().replace(/T.*$/, '')}?mining=${miningFlag}&csv=1`, [dateRange, miningFlag, addr])
   // console.log('csvUrl', csvUrl)
   return (
     <Row>

--- a/src/components/CsvDl/CsvDl.stories.js
+++ b/src/components/CsvDl/CsvDl.stories.js
@@ -7,7 +7,15 @@ export default {
   component: CsvDl
 }
 
-export const CsvDlSt = () => <BtRow><CsvDl addr='pkt1q3rnwa8jw0ucs2qgxlrm06kfxwljlqxpzr85t9r30jv43fj7j29dquswyxt' /></BtRow>
+const dateRange = [
+  new Date('2021-01-02'),
+  new Date('2021-07-01')
+];
+
+export const CsvDlSt = () => <BtRow><CsvDl
+  addr='pkt1q3rnwa8jw0ucs2qgxlrm06kfxwljlqxpzr85t9r30jv43fj7j29dquswyxt'
+  dateRange={dateRange}
+/></BtRow>
 
 CsvDlSt.story = {
   name: 'CsvDl'


### PR DESCRIPTION
# Description

Replace occurrence of base URL with its dynamic counterpart depending on environment variable `REACT_APP_BACKEND_URL`

*Example*:
See [README.md](https://github.com/pkt-cash/pkt-explorer/blob/825596f8a5874e7d6196a5c3a88bb73c9b4d36d7/README.md#installation) about how to change base URL.